### PR TITLE
Fix for recent Google Drive API changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN set -eux; \
         # Updater
         ca-certificates \
         curl \
-        pup \
         xz-utils \
         # Server
         lib32gcc-s1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,14 @@ RUN set -eux; \
         # Updater
         ca-certificates \
         curl \
+        pup \
         xz-utils \
         # Server
         lib32gcc-s1 \
         libstdc++5:i386 \
         libstdc++6:i386 \
         libsdl1.2debian \
-    ; \    
+    ; \
     rm -rf /var/lib/apt/lists/*
 
 # Add local files

--- a/root/app/install.sh
+++ b/root/app/install.sh
@@ -32,23 +32,9 @@ download_install() {
     echo "Downloading ${filename} archive..."
     mkdir -p "${version_directory}"
     if [ -z "${url##*'google.com'*}" ]; then
-        download_url="https://drive.usercontent.google.com/download"
-        # Get the "this file is really big" banner page:
-        curl -#SL -c "${version_directory}/cookies.txt" "${url}" -o "${version_directory}/confirm.html"
-
-        # Extract all confirmation parameters:
-        confirm="$(pup 'form#download-form > input[name=confirm] attr{value}' < "${version_directory}/confirm.html")"
-        uuid="$(pup 'form#download-form > input[name=uuid] attr{value}' < "${version_directory}/confirm.html")"
-        fileid="$(pup 'form#download-form > input[name=id] attr{value}' < "${version_directory}/confirm.html")"
-
-        # Prepare the "final" download URL and download the archive:
-        finalurl="${download_url}?id=${fileid}&export=download&confirm=${confirm}&uuid=${uuid}"
-        curl -#SL -b "${version_directory}/cookies.txt" -o "${download_path}" "${finalurl}"
-
-        # Clean up the cookies and confirmation page:
-        rm -f "${version_directory}/confirm.html" "${version_directory}/cookies.txt"
+        curl -#SL -o "${download_path}" "${url}&export=download&confirm=t"
     else
-        curl -#SL "${url}" -o "${download_path}"
+        curl -#SL -o "${download_path}" "${url}"
     fi
 
     echo "Verifying md5 checksum ${md5}"
@@ -79,6 +65,6 @@ fi
 
 # Install base server with latest patch (3369.2), Epic ECE Bonus Pack, and Bonus Megapack
 download_install \
-    "https://drive.google.com/uc?export=download&id=1yK3QcsE0s-F5weMy-7ACUs-b9VS1AYD_" \
+    "https://drive.usercontent.google.com/download?id=1yK3QcsE0s-F5weMy-7ACUs-b9VS1AYD_" \
     5f9c999ed8f695a67877018ba6a12607 \
     ut2004server_base


### PR DESCRIPTION
~~Google Drive now requires the user to send the unique `uuid` parameter when confirming the "this file is big and may contain viruses" warning. The problem is that this parameter is hidden inside the HTML form present on the warning page, so it has to be parsed out of said page before it can be added to the download URL. This PR adds a [`pup`](https://github.com/ericchiang/pup) HTML parser package to the image and uses it to extract all the needed parameters directly from the HTML warning page.~~

~~The `pup` package itself is small (around 1MiB), so it shouldn't make the image much larger than it was before. In my local tests the image is ~4 MiB larger:~~
```
ut2004                             latest      55d6b21fe9e4   25 minutes ago   202MB
phasecorex/ut2004-server           latest      e38fd4b5d591   6 days ago       198MB
```

Disregard all of the above, we've found a much simpler fix in #19. I just tested it and it works well for me. :)